### PR TITLE
Multiple fixes for Arduino Due

### DIFF
--- a/src/SoftSPI.h
+++ b/src/SoftSPI.h
@@ -40,7 +40,7 @@
 
 #include <SPI.h>
 
-class SoftSPI : public SPIClass {
+class SoftSPI {
     private:
         void wait(uint_fast8_t del);
 


### PR DESCRIPTION
Removed reference to SPIClass which does not exist on Due
Change digitalRead and digitalWrite to directly access pins (this yields a 3x speed increase)
Change SPI_CLOCK_DIVx from switch..case to if statements since on Due two of the values are identical which leads to a compiler issue.